### PR TITLE
Implement prescription configuration and status endpoints, enhance pr…

### DIFF
--- a/code/backend/app/api/v1/prescription.py
+++ b/code/backend/app/api/v1/prescription.py
@@ -30,6 +30,35 @@ def list_prescriptions(
         raise HTTPException(status_code=500, detail=str(e))
 
 
+@router.get("/{task_id}/config", response_model=PrescriptionConfig)
+def get_prescription_config(
+    task_id: str,
+    storage=Depends(get_file_storage_service),
+):
+    """Return per-task prescription configuration (merged JSON), or defaults if none."""
+    try:
+        return prescription_handlers.get_prescription_config(task_id, storage)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/{task_id}/status", response_model=PrescriptionStatusResponse)
+def get_prescription_status(
+    task_id: str,
+    storage=Depends(get_file_storage_service),
+):
+    """
+    Return status for prescription generation for a task.
+
+    This is intended for polling from the frontend, similar to the orthophoto
+    stitching status endpoint.
+    """
+    try:
+        return prescription_handlers.get_prescription_status(task_id, storage)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
 @router.get("/{task_id}")
 def get_prescription(
     task_id: str,
@@ -73,30 +102,13 @@ def update_prescription(
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.get("/{task_id}/status", response_model=PrescriptionStatusResponse)
-def get_prescription_status(
-    task_id: str,
-    storage=Depends(get_file_storage_service),
-):
-    """
-    Return status for prescription generation for a task.
-
-    This is intended for polling from the frontend, similar to the orthophoto
-    stitching status endpoint.
-    """
-    try:
-        return prescription_handlers.get_prescription_status(task_id, storage)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-
 @router.put("/{task_id}/config", response_model=PrescriptionConfig)
 def set_prescription_config(
     task_id: str,
     body: PrescriptionConfig,
     storage=Depends(get_file_storage_service),
 ):
-    """Set or update per-task configuration for the prescription module."""
+    """Set or merge per-task configuration for the prescription module."""
     try:
         return prescription_handlers.set_prescription_config(task_id, body, storage)
     except Exception as e:

--- a/code/backend/app/handlers/prescription.py
+++ b/code/backend/app/handlers/prescription.py
@@ -46,6 +46,69 @@ def _normalize_fid(value: Any) -> Optional[str]:
     return str(value)
 
 
+def _gpa_for_spray_level(config: Dict[str, Any], spray: str) -> Optional[float]:
+    key = {
+        "none": "spray_rate_gpa_none",
+        "low": "spray_rate_gpa_low",
+        "high": "spray_rate_gpa_high",
+    }.get(spray)
+    if key is None:
+        return None
+    val = config.get(key)
+    if val is None:
+        return None
+    return float(val)
+
+
+def apply_spray_rate_gpa_to_geojson(geojson: Dict[str, Any], config: Dict[str, Any]) -> None:
+    """
+    Set properties.spray_rate_gpa on each feature from properties.spray and config thresholds.
+    Removes spray_rate_gpa when the level has no threshold.
+    """
+    features = geojson.get("features")
+    if not isinstance(features, list):
+        return
+
+    for feature in features:
+        if not isinstance(feature, dict):
+            continue
+        props = feature.get("properties")
+        if not isinstance(props, dict):
+            continue
+        spray = props.get("spray")
+        if spray not in ("none", "low", "high"):
+            props.pop("spray_rate_gpa", None)
+            continue
+        gpa = _gpa_for_spray_level(config, spray)
+        if gpa is None:
+            props.pop("spray_rate_gpa", None)
+        else:
+            props["spray_rate_gpa"] = gpa
+
+
+def _write_prescription_geojson(path: Path, geojson: Dict[str, Any]) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    try:
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(geojson, f, ensure_ascii=False, indent=2)
+        tmp_path.replace(path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
+
+
+def refresh_prescription_spray_rates(task_id: str, storage: FileStorageService) -> None:
+    """Recompute spray_rate_gpa on all features from config; no-op if no prescription file."""
+    path = storage.get_prescription_path(task_id)
+    if not path:
+        return
+    config = storage.read_prescription_config(task_id) or {}
+    with open(path, "r", encoding="utf-8") as f:
+        geojson: Dict[str, Any] = json.load(f)
+    apply_spray_rate_gpa_to_geojson(geojson, config)
+    _write_prescription_geojson(Path(path), geojson)
+
+
 def update_prescription(
     task_id: str,
     body: PrescriptionUpdateRequest,
@@ -89,15 +152,11 @@ def update_prescription(
                 feature["properties"]["spray"] = updates_by_id[fid_str]
                 break
 
+    config = storage.read_prescription_config(task_id) or {}
+    apply_spray_rate_gpa_to_geojson(geojson, config)
+
     path = Path(path)
-    tmp_path = path.with_suffix(path.suffix + ".tmp")
-    try:
-        with open(tmp_path, "w", encoding="utf-8") as f:
-            json.dump(geojson, f, ensure_ascii=False, indent=2)
-        tmp_path.replace(path)
-    finally:
-        if tmp_path.exists():
-            tmp_path.unlink(missing_ok=True)
+    _write_prescription_geojson(path, geojson)
 
     return geojson
 
@@ -148,16 +207,28 @@ def get_prescription_status(
     return PrescriptionStatusResponse(taskId=task_id, status=status, message=message)
 
 
+def get_prescription_config(task_id: str, storage: FileStorageService) -> PrescriptionConfig:
+    """Return merged prescription config for a task, or empty defaults if none exists."""
+    raw = storage.read_prescription_config(task_id)
+    if not raw:
+        return PrescriptionConfig()
+    return PrescriptionConfig.model_validate(raw)
+
+
 def set_prescription_config(
     task_id: str,
     config: PrescriptionConfig,
     storage: FileStorageService,
 ) -> PrescriptionConfig:
     """
-    Store per-task configuration for the prescription job.
+    Merge and store per-task configuration for the prescription job.
 
-    This does not immediately trigger a re-run; it only persists configuration
-    that will be used the next time the prescription module is invoked.
+    Incoming fields overlay existing JSON so partial updates preserve other keys.
+    After saving, refreshes spray_rate_gpa on the prescription GeoJSON when present.
     """
-    storage.write_prescription_config(task_id, config.model_dump(exclude_none=True))
-    return config
+    existing = storage.read_prescription_config(task_id) or {}
+    incoming = config.model_dump(exclude_none=True)
+    merged: Dict[str, Any] = {**existing, **incoming}
+    storage.write_prescription_config(task_id, merged)
+    refresh_prescription_spray_rates(task_id, storage)
+    return PrescriptionConfig.model_validate(merged)

--- a/code/backend/app/schemas/prescription_config.py
+++ b/code/backend/app/schemas/prescription_config.py
@@ -2,11 +2,13 @@
 
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 
 class PrescriptionConfig(BaseModel):
     """Configuration for running the prescription R module for a task."""
+
+    model_config = ConfigDict(extra="ignore")
 
     heading: Optional[float] = None
     cell_size: Optional[float] = None
@@ -15,4 +17,7 @@ class PrescriptionConfig(BaseModel):
     smoothing_sigma: Optional[int] = None
     maximum_vertices: Optional[int] = None
     ndvi_threshold: Optional[float] = None
+    spray_rate_gpa_none: Optional[float] = None
+    spray_rate_gpa_low: Optional[float] = None
+    spray_rate_gpa_high: Optional[float] = None
 

--- a/code/backend/tests/test_handlers_prescription.py
+++ b/code/backend/tests/test_handlers_prescription.py
@@ -13,6 +13,7 @@ from app.schemas.prescription import (
     PrescriptionUpdateItem,
     PrescriptionUpdateRequest,
 )
+from app.schemas.prescription_config import PrescriptionConfig
 from app.services.file_storage import FileStorageService
 
 MINIMAL_GEOJSON = {"type": "FeatureCollection", "features": [{"type": "Feature", "id": "1", "properties": {}, "geometry": None}]}
@@ -65,6 +66,24 @@ def test_update_prescription_applies_updates_and_returns_geojson(results_dir: Pa
     assert on_disk["features"][0]["properties"]["spray"] == "high"
 
 
+def test_update_prescription_sets_spray_rate_gpa_from_config(results_dir: Path):
+    """update_prescription writes spray_rate_gpa from prescription_config thresholds."""
+    storage = FileStorageService(results_dir=results_dir)
+    task_id = "task-gpa"
+    task_dir = results_dir / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "prescription.geojson").write_text(json.dumps(MINIMAL_GEOJSON))
+    (task_dir / "prescription_config.json").write_text(
+        json.dumps({"spray_rate_gpa_high": 12.5, "spray_rate_gpa_low": 5.0, "spray_rate_gpa_none": 0.0})
+    )
+    body = PrescriptionUpdateRequest(updates=[PrescriptionUpdateItem(featureId="1", spray="high")])
+    result = prescription_handlers.update_prescription(task_id, body, storage)
+    assert result["features"][0]["properties"]["spray_rate_gpa"] == 12.5
+    with open(task_dir / "prescription.geojson", "r", encoding="utf-8") as f:
+        on_disk = json.load(f)
+    assert on_disk["features"][0]["properties"]["spray_rate_gpa"] == 12.5
+
+
 def test_update_prescription_cluster_id_applies_updates_and_returns_geojson(results_dir: Path):
     """update_prescription applies spray updates when GeoJSON has no feature id but has properties.cluster."""
     storage = FileStorageService(results_dir=results_dir)
@@ -115,3 +134,53 @@ def test_list_prescriptions_empty_returns_empty_items():
     result = prescription_handlers.list_prescriptions(storage)
     assert isinstance(result, PrescriptionListResponse)
     assert result.items == []
+
+
+def test_get_prescription_config_empty_returns_defaults(results_dir: Path):
+    """get_prescription_config with no file returns PrescriptionConfig with unset fields."""
+    storage = FileStorageService(results_dir=results_dir)
+    task_id = "task-cfg-empty"
+    (results_dir / task_id).mkdir(parents=True)
+    cfg = prescription_handlers.get_prescription_config(task_id, storage)
+    assert isinstance(cfg, PrescriptionConfig)
+    assert cfg.heading is None
+    assert cfg.spray_rate_gpa_low is None
+
+
+def test_set_prescription_config_merges_and_refreshes_spray_rate_gpa(results_dir: Path):
+    """set_prescription_config merges JSON and updates spray_rate_gpa on prescription features."""
+    storage = FileStorageService(results_dir=results_dir)
+    task_id = "task-cfg-merge"
+    task_dir = results_dir / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "prescription_config.json").write_text(json.dumps({"heading": 90.0, "cluster_count": 3}))
+    geo = {
+        "type": "FeatureCollection",
+        "features": [
+            {
+                "type": "Feature",
+                "id": "1",
+                "properties": {"spray": "low"},
+                "geometry": None,
+            }
+        ],
+    }
+    (task_dir / "prescription.geojson").write_text(json.dumps(geo))
+
+    out = prescription_handlers.set_prescription_config(
+        task_id,
+        PrescriptionConfig(spray_rate_gpa_low=7.25),
+        storage,
+    )
+    assert out.heading == 90.0
+    assert out.cluster_count == 3
+    assert out.spray_rate_gpa_low == 7.25
+
+    with open(task_dir / "prescription_config.json", "r", encoding="utf-8") as f:
+        merged = json.load(f)
+    assert merged["heading"] == 90.0
+    assert merged["spray_rate_gpa_low"] == 7.25
+
+    with open(task_dir / "prescription.geojson", "r", encoding="utf-8") as f:
+        rx = json.load(f)
+    assert rx["features"][0]["properties"]["spray_rate_gpa"] == 7.25

--- a/code/backend/tests/test_routes.py
+++ b/code/backend/tests/test_routes.py
@@ -293,6 +293,8 @@ def test_prescription_put_valid_body_cluster_only_float_cluster_returns_200_and_
     assert data["features"][0]["properties"]["spray"] == "low"
     get_r = client.get(f"/api/v1/prescription/{task_id}")
     assert get_r.json()["features"][0]["properties"]["spray"] == "low"
+
+
 def test_prescription_put_invalid_body_returns_422(client, results_dir: Path):
     """PUT /api/v1/prescription/{task_id} with invalid body (e.g. invalid spray) returns 422."""
     task_id = "task-rx-422"
@@ -301,3 +303,67 @@ def test_prescription_put_invalid_body_returns_422(client, results_dir: Path):
     (task_dir / "prescription.geojson").write_text('{"type":"FeatureCollection","features":[]}')
     r = client.put(f"/api/v1/prescription/{task_id}", json={"updates": [{"featureId": "1", "spray": "invalid"}]})
     assert r.status_code == 422
+
+
+def test_prescription_get_config_returns_defaults_when_missing(client, results_dir: Path):
+    """GET /api/v1/prescription/{task_id}/config returns 200 with null fields when no config file."""
+    task_id = "task-rx-cfg-get"
+    (results_dir / task_id).mkdir(parents=True)
+    r = client.get(f"/api/v1/prescription/{task_id}/config")
+    assert r.status_code == 200
+    data = r.json()
+    assert data.get("heading") is None
+    assert data.get("spray_rate_gpa_low") is None
+
+
+def test_prescription_get_config_returns_merged_json(client, results_dir: Path):
+    """GET /api/v1/prescription/{task_id}/config returns saved prescription_config.json."""
+    task_id = "task-rx-cfg-get2"
+    task_dir = results_dir / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "prescription_config.json").write_text(
+        json.dumps({"heading": 45.0, "spray_rate_gpa_high": 10.0})
+    )
+    r = client.get(f"/api/v1/prescription/{task_id}/config")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["heading"] == 45.0
+    assert data["spray_rate_gpa_high"] == 10.0
+
+
+def test_prescription_put_config_merges_and_sets_spray_rate_gpa_on_geojson(client, results_dir: Path):
+    """PUT config merges with existing file and refreshes spray_rate_gpa on prescription.geojson."""
+    task_id = "task-rx-cfg-put"
+    task_dir = results_dir / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "prescription_config.json").write_text(json.dumps({"cluster_count": 3}))
+    geojson = {
+        "type": "FeatureCollection",
+        "features": [{"type": "Feature", "id": "1", "properties": {"spray": "high"}, "geometry": None}],
+    }
+    (task_dir / "prescription.geojson").write_text(json.dumps(geojson))
+    r = client.put(
+        f"/api/v1/prescription/{task_id}/config",
+        json={"spray_rate_gpa_high": 8.5},
+    )
+    assert r.status_code == 200
+    assert r.json()["cluster_count"] == 3
+    assert r.json()["spray_rate_gpa_high"] == 8.5
+    get_rx = client.get(f"/api/v1/prescription/{task_id}")
+    assert get_rx.json()["features"][0]["properties"]["spray_rate_gpa"] == 8.5
+
+
+def test_prescription_put_with_config_sets_spray_rate_gpa(client, results_dir: Path):
+    """PUT prescription updates spray_rate_gpa when thresholds exist in config."""
+    task_id = "task-rx-put-gpa"
+    task_dir = results_dir / task_id
+    task_dir.mkdir(parents=True)
+    (task_dir / "prescription_config.json").write_text(json.dumps({"spray_rate_gpa_low": 4.0}))
+    geojson = {"type": "FeatureCollection", "features": [{"type": "Feature", "id": "1", "properties": {}, "geometry": None}]}
+    (task_dir / "prescription.geojson").write_text(json.dumps(geojson))
+    r = client.put(
+        f"/api/v1/prescription/{task_id}",
+        json={"updates": [{"featureId": "1", "spray": "low"}]},
+    )
+    assert r.status_code == 200
+    assert r.json()["features"][0]["properties"]["spray_rate_gpa"] == 4.0

--- a/code/frontend/src/components/GalleryView.tsx
+++ b/code/frontend/src/components/GalleryView.tsx
@@ -11,7 +11,7 @@ const GalleryView: React.FC = () => {
   const [previewUrl, setPreviewUrl] = useState<string>('');
   const [previewTitle, setPreviewTitle] = useState<string>('');
   const [blobObjectUrl, setBlobObjectUrl] = useState<string | null>(null);
-  const [numPages, setNumPages] = useState<number | null>(null);
+  const [, setNumPages] = useState<number | null>(null);
   const [pageNumber, setPageNumber] = useState<number>(1);
 
   pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.min.js`;

--- a/code/frontend/src/components/PesticidePrescriptionsView.tsx
+++ b/code/frontend/src/components/PesticidePrescriptionsView.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { MapContainer, TileLayer, GeoJSON, useMap } from 'react-leaflet';
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -9,7 +9,9 @@ import type {
   SprayLevel,
   PrescriptionGeoJSON,
   PrescriptionFeature,
+  PrescriptionConfig,
 } from '../types/prescription';
+import { computePrescriptionTotalGallons } from '../utils/prescriptionGallons';
 
 delete (L.Icon.Default.prototype as unknown as { _getIconUrl?: string })._getIconUrl;
 L.Icon.Default.mergeOptions({
@@ -41,6 +43,12 @@ const PesticidePrescriptionsView: React.FC = () => {
   const [detailLoading, setDetailLoading] = useState(false);
   const [sprayUpdates, setSprayUpdates] = useState<Record<string, SprayLevel>>({});
   const [savingSpray, setSavingSpray] = useState(false);
+  const [detailConfig, setDetailConfig] = useState<PrescriptionConfig | null>(null);
+  const [thresholdsModalOpen, setThresholdsModalOpen] = useState(false);
+  const [savingThresholds, setSavingThresholds] = useState(false);
+  const [draftGpaNone, setDraftGpaNone] = useState('');
+  const [draftGpaLow, setDraftGpaLow] = useState('');
+  const [draftGpaHigh, setDraftGpaHigh] = useState('');
 
   // Deterministic palette for visually distinguishing cluster polygons.
   // (Only used when `properties.spray` is not set for a feature.)
@@ -81,14 +89,18 @@ const PesticidePrescriptionsView: React.FC = () => {
     setDetailGeojson(null);
     setDetailStatus(null);
     setSprayUpdates({});
+    setDetailConfig(null);
+    setThresholdsModalOpen(false);
     setDetailLoading(true);
     try {
-      const [geojson, status] = await Promise.all([
+      const [geojson, status, cfg] = await Promise.all([
         apiService.getPrescription(taskId),
         apiService.getPrescriptionStatus(taskId),
+        apiService.getPrescriptionConfig(taskId).catch(() => ({} as PrescriptionConfig)),
       ]);
       setDetailGeojson(geojson?.features ? geojson : null);
       setDetailStatus({ status: status.status, message: status.message });
+      setDetailConfig(cfg);
       const initial: Record<string, SprayLevel> = {};
       if (geojson?.features) {
         for (const f of geojson.features) {
@@ -117,6 +129,8 @@ const PesticidePrescriptionsView: React.FC = () => {
     setDetailGeojson(null);
     setDetailStatus(null);
     setSprayUpdates({});
+    setDetailConfig(null);
+    setThresholdsModalOpen(false);
   }, []);
 
   const getFeatureId = (feature: PrescriptionFeature): string | null => {
@@ -126,17 +140,75 @@ const PesticidePrescriptionsView: React.FC = () => {
     return null;
   };
 
-  const getSprayForFeature = (feature: PrescriptionFeature): SprayLevel => {
+  const getSprayForFeature = useCallback((feature: PrescriptionFeature): SprayLevel => {
     const id = getFeatureId(feature);
     if (id && sprayUpdates[id] !== undefined) return sprayUpdates[id];
     const p = feature.properties?.spray as string | undefined;
     if (p === 'none' || p === 'low' || p === 'high') return p as SprayLevel;
     return 'none';
+  }, [sprayUpdates]);
+
+  const getDisplayGpa = (f: PrescriptionFeature): string => {
+    const spray = getSprayForFeature(f);
+    const direct = f.properties?.spray_rate_gpa;
+    if (direct != null && !Number.isNaN(Number(direct))) return Number(direct).toFixed(2);
+    const c = detailConfig;
+    if (c) {
+      if (spray === 'none' && c.spray_rate_gpa_none != null) return c.spray_rate_gpa_none.toFixed(2);
+      if (spray === 'low' && c.spray_rate_gpa_low != null) return c.spray_rate_gpa_low.toFixed(2);
+      if (spray === 'high' && c.spray_rate_gpa_high != null) return c.spray_rate_gpa_high.toFixed(2);
+    }
+    return '—';
   };
 
   const setSprayForFeature = (featureId: string, level: SprayLevel) => {
     setSprayUpdates((prev) => ({ ...prev, [featureId]: level }));
   };
+
+  const openThresholdsModal = useCallback(() => {
+    const c = detailConfig ?? {};
+    setDraftGpaNone(c.spray_rate_gpa_none != null ? String(c.spray_rate_gpa_none) : '');
+    setDraftGpaLow(c.spray_rate_gpa_low != null ? String(c.spray_rate_gpa_low) : '');
+    setDraftGpaHigh(c.spray_rate_gpa_high != null ? String(c.spray_rate_gpa_high) : '');
+    setThresholdsModalOpen(true);
+  }, [detailConfig]);
+
+  const saveThresholds = useCallback(async () => {
+    if (!selectedTaskId) return;
+    setSavingThresholds(true);
+    try {
+      const current = await apiService.getPrescriptionConfig(selectedTaskId);
+      const merged: PrescriptionConfig = { ...current };
+      if (draftGpaNone.trim() !== '') merged.spray_rate_gpa_none = parseFloat(draftGpaNone);
+      if (draftGpaLow.trim() !== '') merged.spray_rate_gpa_low = parseFloat(draftGpaLow);
+      if (draftGpaHigh.trim() !== '') merged.spray_rate_gpa_high = parseFloat(draftGpaHigh);
+      const saved = await apiService.setPrescriptionConfig(selectedTaskId, merged);
+      setDetailConfig(saved);
+      const geo = await apiService.getPrescription(selectedTaskId);
+      setDetailGeojson(geo?.features ? geo : null);
+      setThresholdsModalOpen(false);
+    } catch (e) {
+      console.error('Failed to save spray thresholds', e);
+    } finally {
+      setSavingThresholds(false);
+    }
+  }, [selectedTaskId, draftGpaNone, draftGpaLow, draftGpaHigh]);
+
+  const totalGallons = useMemo(() => {
+    if (!detailGeojson?.features?.length) return null;
+    return computePrescriptionTotalGallons(detailGeojson, getSprayForFeature, detailConfig);
+  }, [detailGeojson, getSprayForFeature, detailConfig]);
+
+  const previewGallonsInModal = useMemo(() => {
+    if (!detailGeojson?.features?.length) return null;
+    const override: PrescriptionConfig = {
+      ...(detailConfig ?? {}),
+    };
+    if (draftGpaNone.trim() !== '') override.spray_rate_gpa_none = parseFloat(draftGpaNone);
+    if (draftGpaLow.trim() !== '') override.spray_rate_gpa_low = parseFloat(draftGpaLow);
+    if (draftGpaHigh.trim() !== '') override.spray_rate_gpa_high = parseFloat(draftGpaHigh);
+    return computePrescriptionTotalGallons(detailGeojson, getSprayForFeature, override);
+  }, [detailGeojson, getSprayForFeature, detailConfig, draftGpaNone, draftGpaLow, draftGpaHigh]);
 
   const saveSprayUpdates = useCallback(async () => {
     if (!selectedTaskId) return;
@@ -163,19 +235,6 @@ const PesticidePrescriptionsView: React.FC = () => {
         return 'bg-red-500/20 text-red-400';
       default:
         return 'bg-dark-500/20 text-dark-400';
-    }
-  };
-
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'completed':
-        return <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7" />;
-      case 'processing':
-        return <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />;
-      case 'failed':
-        return <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M6 18L18 6M6 6l12 12" />;
-      default:
-        return null;
     }
   };
 
@@ -372,6 +431,7 @@ const PesticidePrescriptionsView: React.FC = () => {
                             const userSpray = fid && sprayUpdates[fid] !== undefined ? sprayUpdates[fid] : undefined;
                             const hasSpray = rawSpray != null || userSpray != null;
                             const sprayText = hasSpray ? getSprayForFeature(f) : 'Not set';
+                            const gpaText = hasSpray ? getDisplayGpa(f) : '—';
 
                             if (fid || cluster != null) {
                               layer.bindPopup(
@@ -380,7 +440,8 @@ const PesticidePrescriptionsView: React.FC = () => {
                                   <strong>Max NDVI (mean):</strong> ${
                                     ndviMaxMean !== undefined && ndviMaxMean !== null ? ndviMaxMean.toFixed(3) : 'N/A'
                                   }<br/>
-                                  <strong>Spray:</strong> ${sprayText}
+                                  <strong>Spray:</strong> ${sprayText}<br/>
+                                  <strong>Rate (gal/ac):</strong> ${gpaText}
                                 </div>`
                               );
                             }
@@ -393,8 +454,15 @@ const PesticidePrescriptionsView: React.FC = () => {
                   <div>
                     <h4 className="text-lg font-medium text-primary-400 mb-2">Spray by cluster</h4>
                     <p className="text-dark-400 text-sm mb-4">
-                      Set spray level per feature and click Save to update the prescription.
+                      Set spray level per feature and click Save spray updates. Configure gallons-per-acre rates for each
+                      level under Configure spray thresholds.
                     </p>
+                    {totalGallons != null && (
+                      <p className="text-dark-200 text-sm mb-3">
+                        <span className="font-medium text-primary-400">Estimated total spray:</span>{' '}
+                        {totalGallons.toFixed(1)} gal
+                      </p>
+                    )}
                     <div className="space-y-2 max-h-64 overflow-y-auto">
                       {detailGeojson.features.map((f, idx) => {
                         const fid = getFeatureId(f) ?? `feature-${idx}`;
@@ -402,16 +470,17 @@ const PesticidePrescriptionsView: React.FC = () => {
                         const cluster = f.properties?.cluster;
                         const ndviMaxMean = f.properties?.NDVI_max_mean;
                         return (
-                          <div key={fid} className="flex items-center justify-between bg-dark-700 rounded px-3 py-2">
+                          <div key={fid} className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 bg-dark-700 rounded px-3 py-2">
                             <span className="text-dark-200 text-sm">
                               {cluster != null ? `Cluster ${cluster}` : fid}
                               {' '}
                               Max NDVI: {ndviMaxMean != null && ndviMaxMean !== undefined ? ndviMaxMean.toFixed(3) : 'N/A'}
+                              <span className="text-dark-400"> · Rate: {getDisplayGpa(f)} gal/ac</span>
                             </span>
                             <select
                               value={spray}
                               onChange={(e) => setSprayForFeature(fid, e.target.value as SprayLevel)}
-                              className="bg-dark-600 text-dark-100 border border-dark-500 rounded px-2 py-1 text-sm"
+                              className="bg-dark-600 text-dark-100 border border-dark-500 rounded px-2 py-1 text-sm shrink-0"
                             >
                               <option value="none">None</option>
                               <option value="low">Low</option>
@@ -421,19 +490,113 @@ const PesticidePrescriptionsView: React.FC = () => {
                         );
                       })}
                     </div>
-                    <button
-                      onClick={saveSprayUpdates}
-                      disabled={savingSpray || Object.keys(sprayUpdates).length === 0}
-                      className="mt-4 px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed"
-                    >
-                      {savingSpray ? 'Saving…' : 'Save spray updates'}
-                    </button>
+                    <div className="mt-4 flex flex-wrap gap-2 items-center">
+                      <button
+                        type="button"
+                        onClick={openThresholdsModal}
+                        className="px-4 py-2 bg-dark-600 text-dark-100 border border-dark-500 rounded-lg hover:bg-dark-500"
+                      >
+                        Configure spray thresholds
+                      </button>
+                      <button
+                        type="button"
+                        onClick={saveSprayUpdates}
+                        disabled={savingSpray || Object.keys(sprayUpdates).length === 0}
+                        className="px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                      >
+                        {savingSpray ? 'Saving…' : 'Save spray updates'}
+                      </button>
+                    </div>
                   </div>
                 </div>
               ) : (
                 <p className="text-dark-400">No GeoJSON features to display.</p>
               )}
             </div>
+
+            {thresholdsModalOpen && (
+              <div
+                className="fixed inset-0 z-[10000] flex items-center justify-center bg-black/60 p-4"
+                onClick={() => setThresholdsModalOpen(false)}
+                role="presentation"
+              >
+                <div
+                  className="bg-dark-800 rounded-lg border border-dark-600 max-w-md w-full p-6 shadow-xl"
+                  onClick={(e) => e.stopPropagation()}
+                  role="dialog"
+                  aria-labelledby="spray-thresholds-title"
+                >
+                  <h4 id="spray-thresholds-title" className="text-lg font-semibold text-primary-400 mb-2">
+                    Spray thresholds (gal/ac)
+                  </h4>
+                  <p className="text-dark-400 text-sm mb-4">
+                    Gallons per acre for each spray level. These are stored in the field config and applied to each cluster
+                    as <span className="text-dark-200">spray_rate_gpa</span> when you save.
+                  </p>
+                  <div className="space-y-3">
+                    <label className="block text-sm text-dark-200">
+                      None
+                      <input
+                        type="number"
+                        min={0}
+                        step="any"
+                        value={draftGpaNone}
+                        onChange={(e) => setDraftGpaNone(e.target.value)}
+                        className="mt-1 w-full bg-dark-700 border border-dark-600 rounded px-3 py-2 text-dark-100"
+                        placeholder="e.g. 0"
+                      />
+                    </label>
+                    <label className="block text-sm text-dark-200">
+                      Low
+                      <input
+                        type="number"
+                        min={0}
+                        step="any"
+                        value={draftGpaLow}
+                        onChange={(e) => setDraftGpaLow(e.target.value)}
+                        className="mt-1 w-full bg-dark-700 border border-dark-600 rounded px-3 py-2 text-dark-100"
+                        placeholder="e.g. 5"
+                      />
+                    </label>
+                    <label className="block text-sm text-dark-200">
+                      High
+                      <input
+                        type="number"
+                        min={0}
+                        step="any"
+                        value={draftGpaHigh}
+                        onChange={(e) => setDraftGpaHigh(e.target.value)}
+                        className="mt-1 w-full bg-dark-700 border border-dark-600 rounded px-3 py-2 text-dark-100"
+                        placeholder="e.g. 12"
+                      />
+                    </label>
+                  </div>
+                  {previewGallonsInModal != null && (
+                    <p className="text-dark-200 text-sm mt-4">
+                      <span className="font-medium text-primary-400">Preview total spray:</span>{' '}
+                      {previewGallonsInModal.toFixed(1)} gal (uses draft rates above with current cluster areas)
+                    </p>
+                  )}
+                  <div className="mt-6 flex gap-2 justify-end flex-wrap">
+                    <button
+                      type="button"
+                      onClick={() => setThresholdsModalOpen(false)}
+                      className="px-4 py-2 bg-dark-600 text-dark-100 border border-dark-500 rounded-lg hover:bg-dark-500"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="button"
+                      onClick={saveThresholds}
+                      disabled={savingThresholds}
+                      className="px-4 py-2 bg-primary-500 text-white rounded-lg hover:bg-primary-600 disabled:opacity-50"
+                    >
+                      {savingThresholds ? 'Saving…' : 'Save thresholds'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/code/frontend/src/services/api.ts
+++ b/code/frontend/src/services/api.ts
@@ -459,6 +459,18 @@ class ApiService {
   }
 
   /**
+   * Get per-task prescription module configuration (merged JSON on disk).
+   */
+  async getPrescriptionConfig(taskId: string): Promise<PrescriptionConfig> {
+    const response = await fetch(`${this.baseUrl}/api/v1/prescription/${taskId}/config`);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`Get prescription config failed: ${response.status} ${text}`);
+    }
+    return response.json();
+  }
+
+  /**
    * Get prescription GeoJSON for a task.
    */
   async getPrescription(taskId: string): Promise<PrescriptionGeoJSON> {

--- a/code/frontend/src/types/prescription.ts
+++ b/code/frontend/src/types/prescription.ts
@@ -37,7 +37,7 @@ export interface PrescriptionUpdateRequest {
   updates: PrescriptionUpdateItem[];
 }
 
-/** Per-task config for PUT /api/v1/prescription/{taskId}/config */
+/** Per-task config for GET/PUT /api/v1/prescription/{taskId}/config */
 export interface PrescriptionConfig {
   heading?: number;
   cell_size?: number;
@@ -46,6 +46,9 @@ export interface PrescriptionConfig {
   smoothing_sigma?: number;
   maximum_vertices?: number;
   ndvi_threshold?: number;
+  spray_rate_gpa_none?: number;
+  spray_rate_gpa_low?: number;
+  spray_rate_gpa_high?: number;
 }
 
 /** Properties on prescription GeoJSON features (R module output). */
@@ -58,6 +61,8 @@ export interface PrescriptionFeatureProperties {
   NDVI_max_mean?: number;
   NDVI_max_max?: number;
   spray?: SprayLevel;
+  /** Gallons per acre for the current spray level (from thresholds). */
+  spray_rate_gpa?: number;
   [key: string]: unknown;
 }
 

--- a/code/frontend/src/utils/prescriptionGallons.ts
+++ b/code/frontend/src/utils/prescriptionGallons.ts
@@ -1,0 +1,40 @@
+import area from '@turf/area';
+import type { Feature, MultiPolygon, Polygon } from 'geojson';
+import type { PrescriptionConfig, PrescriptionFeature, PrescriptionGeoJSON, SprayLevel } from '../types/prescription';
+
+const SQ_M_PER_ACRE = 4046.8564224;
+
+function rateForSprayLevel(spray: SprayLevel, config: PrescriptionConfig | null | undefined): number | undefined {
+  if (!config) return undefined;
+  if (spray === 'none') return config.spray_rate_gpa_none;
+  if (spray === 'low') return config.spray_rate_gpa_low;
+  if (spray === 'high') return config.spray_rate_gpa_high;
+  return undefined;
+}
+
+/**
+ * Total spray volume (gallons) = sum over clusters of (acres × gal/ac).
+ * Uses `properties.spray_rate_gpa` when set; otherwise falls back to config thresholds for the feature's spray level.
+ */
+export function computePrescriptionTotalGallons(
+  geojson: PrescriptionGeoJSON,
+  getSprayLevel: (f: PrescriptionFeature) => SprayLevel,
+  config?: PrescriptionConfig | null
+): number {
+  let total = 0;
+  for (const f of geojson.features) {
+    const geom = f.geometry;
+    if (!geom || (geom.type !== 'Polygon' && geom.type !== 'MultiPolygon')) continue;
+    const sqm = area({ type: 'Feature', properties: {}, geometry: geom } as Feature<Polygon | MultiPolygon>);
+    const acres = sqm / SQ_M_PER_ACRE;
+    const spray = getSprayLevel(f);
+    let rate = f.properties?.spray_rate_gpa;
+    if (rate == null || Number.isNaN(rate)) {
+      const r = rateForSprayLevel(spray, config);
+      if (r == null || Number.isNaN(r)) continue;
+      rate = r;
+    }
+    total += acres * rate;
+  }
+  return total;
+}


### PR DESCRIPTION
…escription handling

- Added `get_prescription_config` and `get_prescription_status` endpoints to retrieve task-specific configurations and statuses.
- Refactored `set_prescription_config` to merge incoming configurations and refresh spray rates in GeoJSON.
- Introduced helper functions for managing spray rate GPA based on configuration thresholds.
- Updated `PrescriptionConfig` schema to include spray rate GPA fields.
- Enhanced tests to cover new configuration retrieval and merging functionalities.